### PR TITLE
Update XML Namespace URI for KML

### DIFF
--- a/latitude_json_converter.py
+++ b/latitude_json_converter.py
@@ -84,7 +84,7 @@ def main(argv):
 
         if args.format == "kml":
             f_out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-            f_out.write("<kml xmlns=\"http://earth.google.com/kml/2.2\">\n")
+            f_out.write("<kml xmlns=\"http://www.opengis.net/kml/2.2\">\n")
             f_out.write("  <Document>\n")
             f_out.write("    <name>Location History</name>\n")
             items = data["data"]["items"]


### PR DESCRIPTION
The XML Namespace http://earth.google.com/kml/2.2 returns a 404,
as do other similar Google URIs for KML 2.2.  This causes the output
not to validate.  Changed to http://www.opengis.net/kml/2.2
