### PR TITLE
Add GPX Support

### DIFF
--- a/README
+++ b/README
@@ -1,15 +1,15 @@
 This simple python script takes a Latitude JSON File which you can get via Google Takeout (https://www.google.com/takeout/?pli=1#custom:latitude) and converts it into other formats.
 
 Usage:
-latitude_json_converter.py input output [-h] [-f {kml,json,csv,js,gpx}] [-v]
+latitude_json_converter.py input output [-h] [-f {kml,json,csv,js,gpx,gpxtracks}] [-v]
 
 input                Input File (JSON)
 output               Output File (will be overwritten without prompt!)
 
 optional arguments:
-  -h, --help                          Show this help message and exit
-  -f, --format {kml,json,csv,js,gpx}  Format of the output
-  -v, --variable                      Variable name for js export
+  -h, --help                                    Show this help message and exit
+  -f, --format {kml,json,csv,js,gpx,gpxtracks}  Format of the output
+  -v, --variable                                Variable name for js export
 
 
 Available formats:
@@ -27,6 +27,9 @@ js:
 JavaScript File which sets a variable in global namespace (default: window.latitudeJsonData) to the full data object for easy access in local scripts. Just include the js file before your actual script.
 
 gpx:
+GPS Exchange Format including location, timestamp, and accuracy/speed/altitude as available.  Data produced is valid GPX 1.1.  Points are stored as individual, unrelated waypoints (like the other formats, except for gpxtracks).
+
+gpxtracks:
 GPS Exchange Format including location, timestamp, and accuracy/speed/altitude as available.  Data produced is valid GPX 1.1.  Points are grouped together into tracks by time and location (specifically, two chronological points split a track if they differ by over 10 minutes or approximately 40 kilometers).
 
 ----------------------


### PR DESCRIPTION
This should be a very nice addition, though it makes the script a little less simple!  I added support for the common GPX format.  It is valid GPX 1.1, works in Google Earth, and includes location, timestamp, and altitude/speed/accuracy when it's available.  It includes two new formats: "gpx" and "gpxtracks."  The first is like the others, and the second (which requires two additional functions and the math library), allows grouping of points into tracks.  It divides tracks where there was no data for over 10 minutes (split of a logical track), or if two data points jumped over approximately 40 kilometers (split based on likely error).  I updated the README as well.

I hope (or others) you find these additions useful and not too bulky.  I have tested them a fair amount.  This branch was developed in sync with the update-kml-valid branch to make two separate pull requests.  There should be no conflicting changes, so I do hope the merge is clear and simple, should you accept both pull requests.

Thanks again!
