### PR TITLE
startendtime (attempt 2)

### DIFF
--- a/location_history_json_converter.py
+++ b/location_history_json_converter.py
@@ -558,14 +558,14 @@ def main():
         print("Error creating output file for writing: %s" % error)
         return
 
-    if args.enddate:
-        args.enddate = args.enddate.replace(hour=23, minute=59, second=59, microsecond=999999)
-
     if args.startdate and args.starttime:
         args.startdate = args.startdate + timedelta(hours=args.starttime.hour,minutes=args.starttime.minute)
 
-    if args.enddate and args.endtime:
-        args.enddate = args.enddate + timedelta(hours=args.endtime.hour,minutes=args.endtime.minute)
+    if args.enddate:
+        if args.endtime:
+            args.enddate = args.enddate + timedelta(hours=args.endtime.hour,minutes=args.endtime.minute) - timedelta(microseconds=1)
+        else:
+            args.enddate = args.enddate.replace(hour=23, minute=59, second=59, microsecond=999999)
 
     convert(
         items, f_out,

--- a/location_history_json_converter.py
+++ b/location_history_json_converter.py
@@ -441,8 +441,8 @@ def main():
         action="store_true"
     )
 
-    arg_parser.add_argument("-s", "--startdate", help="The Start Date - format YYYY-MM-DD (defaults to 0h00)", type=_valid_date)
-    arg_parser.add_argument("-e", "--enddate", help="The End Date - format YYYY-MM-DD (defaults to 0h00)", type=_valid_date)
+    arg_parser.add_argument("-s", "--startdate", help="The Start Date - format YYYY-MM-DD (defaults to 0h00m)", type=_valid_date)
+    arg_parser.add_argument("-e", "--enddate", help="The End Date - format YYYY-MM-DD (defaults to 23h59m59s)", type=_valid_date)
     arg_parser.add_argument("--starttime", help="The Start Time - format HH:MM, only used if Start Date is set", type=_valid_time)
     arg_parser.add_argument("--endtime", help="The End Time - format HH:MM, only used if End Date is set", type=_valid_time)
     arg_parser.add_argument("-a", "--accuracy", help="Maximum accuracy (in meters), lower is better.", type=int)
@@ -566,6 +566,9 @@ def main():
 
     if args.enddate and args.endtime:
         args.enddate = args.enddate + timedelta(hours=args.endtime.hour,minutes=args.endtime.minute)
+
+    print(args.startdate)
+    print(args.enddate)
 
     convert(
         items, f_out,

--- a/location_history_json_converter.py
+++ b/location_history_json_converter.py
@@ -24,6 +24,7 @@ import json
 import math
 from argparse import ArgumentParser, ArgumentTypeError
 from datetime import datetime
+from datetime import timedelta
 
 try:
     import ijson
@@ -559,6 +560,12 @@ def main():
 
     if args.enddate:
         args.enddate = args.enddate.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+    if args.startdate and args.starttime:
+        args.startdate = args.startdate + timedelta(hours=args.starttime.hour,minutes=args.starttime.minute)
+
+    if args.enddate and args.endtime:
+        args.enddate = args.enddate + timedelta(hours=args.endtime.hour,minutes=args.endtime.minute)
 
     convert(
         items, f_out,

--- a/location_history_json_converter.py
+++ b/location_history_json_converter.py
@@ -567,9 +567,6 @@ def main():
     if args.enddate and args.endtime:
         args.enddate = args.enddate + timedelta(hours=args.endtime.hour,minutes=args.endtime.minute)
 
-    print(args.startdate)
-    print(args.enddate)
-
     convert(
         items, f_out,
         format=args.format,

--- a/location_history_json_converter.py
+++ b/location_history_json_converter.py
@@ -47,6 +47,12 @@ def _valid_date(s):
         msg = "Not a valid date: '{0}'.".format(s)
         raise ArgumentTypeError(msg)
 
+def _valid_time(s):
+    try:
+        return datetime.strptime(s, "%H:%M")
+    except ValueError:
+        msg = "Not a valid time: '{0}'.".format(s)
+        raise ArgumentTypeError(msg)
 
 def _valid_polygon(s):
     try:
@@ -434,8 +440,10 @@ def main():
         action="store_true"
     )
 
-    arg_parser.add_argument("-s", "--startdate", help="The Start Date - format YYYY-MM-DD (0h00)", type=_valid_date)
-    arg_parser.add_argument("-e", "--enddate", help="The End Date - format YYYY-MM-DD (0h00)", type=_valid_date)
+    arg_parser.add_argument("-s", "--startdate", help="The Start Date - format YYYY-MM-DD (defaults to 0h00)", type=_valid_date)
+    arg_parser.add_argument("-e", "--enddate", help="The End Date - format YYYY-MM-DD (defaults to 0h00)", type=_valid_date)
+    arg_parser.add_argument("--starttime", help="The Start Time - format HH:MM, only used if Start Date is set", type=_valid_time)
+    arg_parser.add_argument("--endtime", help="The End Time - format HH:MM, only used if End Date is set", type=_valid_time)
     arg_parser.add_argument("-a", "--accuracy", help="Maximum accuracy (in meters), lower is better.", type=int)
 
     arg_parser.add_argument(


### PR DESCRIPTION
This pull request adds --starttime and --endtime arguments. The arguments are only used when the corresponding date argument is set (e.g. starttime requires startdate and so on).

For example, `--startdate 2012-05-01 --starttime 07:00` will use "2012-05-01 07:00" as the start date/time and `--enddate 2012-05-02 --endtime 07:00` will use "2012-05-02 06:59:59.999999" as the end date/time.

Note that this improves on my previous (closed) pull request by making the endtime argument much more intuitive. It also leaves the existing functionality exactly the same so omitting the starttime and endtime arguments should run exactly as before.

Please do review the code before merging as I am new to GitHub and haven't done any serious coding in a decade.