### PR TITLE
Add convertion type geojson

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ You can then install Shapely using this command:
 
     python -m pip install Shapely-X-cpX-cpXm-winX.whl
 
+#### `-f geojson`
+
+Using the geojson convertion type requires the geojson library which can be installed with
+
+    pip install geojson
 
 ### Available formats
 
@@ -108,8 +113,11 @@ that can then be handled without iterative mode (necessary for gpxtracks and the
 
 #### gpx
 GPS Exchange Format including location, timestamp, and accuracy/speed/altitude as available.
-Data produced is valid GPX 1.1.  Points are stored as individual, unrelated waypoints (like the other formats, except for gpxtracks).
+Data produced is valid GPX 1.1. Points are stored as individual, unrelated waypoints (like the other formats, except for gpxtracks).
 
 #### gpxtracks
 GPS Exchange Format including location, timestamp, and accuracy/speed/altitude as available.
-Data produced is valid GPX 1.1.  Points are grouped together into tracks by time and location (specifically, two chronological points split a track if they differ by over 10 minutes or approximately 40 kilometers).
+Data produced is valid GPX 1.1. Points are grouped together into tracks by time and location (specifically, two chronological points split a track if they differ by over 10 minutes or approximately 40 kilometers).
+
+#### geojson
+Produces a JSON file with a geojson line string containing the points.


### PR DESCRIPTION
Not fully tested yet, open for feedback.

I tested it with a 1 GB json file with the command `python3.9 location_history_json_converter.py -f geojson -i -s 2021-05-01 Takeout/Location\ History/Location\ History.json test.geojson` and it does what I need atm.

Possible optimizations:

- Remove geojson dependency
- Remove the need for the `geojson_data` variable where even with the `-i` option all coordinates are stored before writing them in `_write_footer()`
- Add feature like in converter type `gpxtracks` where a new track is created if coordinates differ by some measure