### PR TITLE
Add support for Google Timeline rawSignals JSON format

### DIFF
--- a/location_history_json_converter.py
+++ b/location_history_json_converter.py
@@ -547,11 +547,11 @@ def main():
             print("ijson is not available. Please install with `pip install ijson` and try again.")
             return
 
-        items = ijson.items(open(args.input, "r"), "locations.item")
+        items = ijson.items(open(args.input, "r", encoding="utf-8"), "locations.item")
 
     else:
         try:
-            with open(args.input, "r") as f:
+            with open(args.input, "r", encoding="utf-8") as f:
                 json_data = f.read()
         except OSError as error:
             print("Error opening input file %s: %s" % (args.input, error))
@@ -566,7 +566,39 @@ def main():
             print("Error decoding json: %s" % error)
             return
 
-        items = data["locations"]
+        if "locations" in data:
+            items = data["locations"]
+        elif "rawSignals" in data:
+            items = []
+            for signal in data["rawSignals"]:
+                if "position" not in signal:
+                    continue
+                pos = signal["position"]
+                if "LatLng" not in pos:
+                    continue
+                if "timestamp" not in pos or not pos.get("timestamp"):
+                    continue
+                # LatLng format: "35.0537963°, 135.6730386°"
+                lat_str, lon_str = pos["LatLng"].split(",")
+                # Extract only numeric characters, stripping the degree symbol
+                lat = float("".join(c for c in lat_str if c.isdigit() or c in ".-"))
+                lon = float("".join(c for c in lon_str if c.isdigit() or c in ".-"))
+                
+                item = {
+                    "latitudeE7": int(lat * 1e7),
+                    "longitudeE7": int(lon * 1e7),
+                    "timestamp": pos["timestamp"]
+                }
+                if "accuracyMeters" in pos:
+                    item["accuracy"] = pos["accuracyMeters"]
+                if "altitudeMeters" in pos:
+                    item["altitude"] = pos["altitudeMeters"]
+                if "speedMetersPerSecond" in pos:
+                    item["speed"] = pos["speedMetersPerSecond"]
+                items.append(item)
+        else:
+            print("Unknown JSON format: neither 'locations' nor 'rawSignals' found.")
+            return
 
     try:
         f_out = open(args.output, "w")


### PR DESCRIPTION
## Problem

Google Takeout changed the Timeline export format. The new JSON uses `rawSignals` and `semanticSegments` instead of the `locations` array. The converter crashes with `KeyError: 'locations'` on the new format.

## Changes

- Added a fallback parser for the new `rawSignals` schema
- Parses coordinates from `signal.position.LatLng` (format: `35.05°, 135.67°`)
- Extracts timestamps from `signal.position.timestamp`
- Maps `accuracyMeters`, `altitudeMeters`, `speedMetersPerSecond` to the existing internal format
- Opens input files with explicit `encoding='utf-8'` to prevent issues on Windows (where the default cp1252 encoding mangles the degree symbol)
- Preserves full backward compatibility with the old `locations` format

## Testing

Tested with a real Google Takeout export (Feb-Mar 2026), generating a GPX track with 4,741 location points. The output was used to successfully geotag 1,272 photos via ExifTool.

## Notes

- This PR only handles `rawSignals` (actual GPS pings). The `semanticSegments` data (processed visits/activities) is intentionally not included as it proved too coarse for practical use in geotagging workflows.